### PR TITLE
Support PositionColorTexLightmapShader - Adds support for TiC Fluids

### DIFF
--- a/src/main/java/net/coderbot/iris/mixin/MixinGameRenderer.java
+++ b/src/main/java/net/coderbot/iris/mixin/MixinGameRenderer.java
@@ -139,7 +139,7 @@ public class MixinGameRenderer {
 		}
 	}
 
-	// TODO: getPositionColorLightmapShader, getPositionColorTexLightmapShader
+	// TODO: getPositionColorLightmapShader
 
 	@Inject(method = "getPositionTexColorNormalShader", at = @At("HEAD"), cancellable = true)
 	private static void iris$overridePositionTexColorNormalShader(CallbackInfoReturnable<ShaderInstance> cir) {
@@ -351,7 +351,8 @@ public class MixinGameRenderer {
 
 	@Inject(method = {
 			"getRendertypeTextShader",
-			"getRendertypeTextSeeThroughShader"
+			"getRendertypeTextSeeThroughShader",
+			"getPositionColorTexLightmapShader"
 	}, at = @At("HEAD"), cancellable = true)
 	private static void iris$overrideTextShader(CallbackInfoReturnable<ShaderInstance> cir) {
 		if (ShadowRenderer.ACTIVE) {


### PR DESCRIPTION
Original Commit:
https://github.com/IrisShaders/Iris/commit/b3f00643f3a33d20c0fdf46de1a81a3d8db3e1f9

I wanted to see why fluid rendering in tanks and the smeltery doesn't work. Turns out the shader wasn't supported, but Iris already fixed it. Figured I'd drop you the fix as a PR, based on the Iris change. Seems to work fine if I build it myself.

I think it's not perfect, but it should stop most complaints about TiC + shader compatibility at least.