### PR TITLE
Fix broken rendering of shaders on AMD cards

### DIFF
--- a/src/main/resources/centerDepth.fsh
+++ b/src/main/resources/centerDepth.fsh
@@ -9,7 +9,7 @@ uniform float lastFrameTime;
 uniform float decay;
 
 #ifdef IS_GL3
-out float output;
+out float oculus_fragColor;
 #endif
 
 void main() {
@@ -22,11 +22,11 @@ void main() {
         oldDepth = currentDepth;
     }
 
-    output = mix(oldDepth, currentDepth, decay2);
+    oculus_fragColor = mix(oldDepth, currentDepth, decay2);
     #else
     if (oldDepth != oldDepth) { // cheap isNaN
        oldDepth = currentDepth;
     }
-    gl_FragColor = vec4(mix(, currentDepth, decay2), 0, 0, 0);
+    gl_FragColor = vec4(mix(texture2D(altDepth, vec2(0.5)).r, currentDepth, decay2), 0, 0, 0);
     #endif
 }


### PR DESCRIPTION
This fix has been tested with the following shader packs:

`BSL_v8.2.zip`
`MakeUp-UltraFast-8.6g.zip`
`Sildur's+Enhanced+Default+v1.141+Fast.zip`

with the following hardware configurations:

`i7 6700HQ + Nvidia GTX 1070, driver version 497.29, w/ Windows 10 OpenJDK 8`
`AMD Ryzen 5600x + AMD RX 6900 XT, amdgpu driver on mesa 22.2.3-1, w/ Arch Linux GraalVM EE 22.3.0 JDK 8 and 11`
`i5-3210M + iGPU [Max OpenGL Level = 4.2], i915 driver on mesa 22.2.3-1, w/ Arch Linux OpenJDK 8`

on all configurations, I saw correct rendering of all tested shaders. Earlier reports from me that there may have been some incorrect rendering were due to incompatibilities with flywheel. After removing flywheel, all shaders rendered accurately in my limited investigation. Of the tested shaders, BSL and MakeUp both worked without errors even with flywheel installed. Silder's, however causes a ton of log spam and has various graphical issues (see log example posted here: https://github.com/Asek3/Oculus/issues/226#issuecomment-1331349676). This is a regression compared to v1.2.6, which did not spam the log with errors (and render broadly incorrectly) while flywheel was installed and Silder's shader was loaded. However, MakeUp had many issues with layered transparency and replections (ex: water behind glass), and incorrect underwater rendering with flywheel in 1.2.6. These particular problems are resolved in 1.4.3 with this fix, so its unclear if changes to `centerDepth.fsh` are to blame. This is especially true given that reported incompatibilities between Silder's shaders and flywheel exist even in newer minecraft versions (see https://github.com/Sildurs-shaders/sildurs-shaders.github.io/issues/242)

TL;DR: I think this fix is safe to merge for all hardware given that it worked correctly when tested on AMD, Intel, and Nvidia systems. It has exposed potential new bugs needing addressing (and the possibility that the this fix is causing them has not been 100% ruled out), but it is an improvement over the current 1.4.3 state.

The changed file can even be merged into existing 1.4.3 jar files to provide the fix, should this PR not get merged or take some time to get merged for the impatient.