### PR TITLE
Added the minVersion tag

### DIFF
--- a/src/main/resources/mixins.oculus.compat.sodium.json
+++ b/src/main/resources/mixins.oculus.compat.sodium.json
@@ -1,6 +1,7 @@
 {
   "package": "net.coderbot.iris.compat.sodium.mixin",
   "plugin": "net.coderbot.iris.compat.sodium.mixin.IrisSodiumCompatMixinPlugin",
+  "minVersion": "0.8",
   "refmap": "oculus-refmap.json",
   "required": true,
   "compatibilityLevel": "JAVA_8",


### PR DESCRIPTION
To fix this: 
```
[main/ERROR]: Mixin config mixins.oculus.compat.sodium.json does not specify "minVersion" property
```
I added the minVersion tag, as it was not specified before.