### PR TITLE
Fix running in dev

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,20 @@ sourceSets {
 	}
 }
 
+loom {
+	runs {
+		client {
+			mods {
+				oculus {
+					sourceSet sourceSets.main
+					sourceSet sourceSets.vendored
+					sourceSet sourceSets.sodiumCompatibility
+				}
+			}
+		}
+	}
+}
+
 repositories {
 	maven {
 		name = "Modrinth"
@@ -83,9 +97,10 @@ dependencies {
 	modCompileOnly "org.embeddedt:embeddium-${minecraft_version}:${embeddium_version}"
 	compileOnly "maven.modrinth:distanthorizons:2.0.1-a-1.20.1"
 
-	implementation shadow("io.github.douira:glsl-transformer:2.0.0")
-	implementation shadow("org.antlr:antlr4-runtime:4.11.1")
-	implementation include("org.anarres:jcpp:1.4.14")
+	forgeRuntimeLibrary(implementation(shadow(project(path: ":glsl-relocated", configuration: "bundledJar")))) {
+		transitive = false
+	}
+	forgeRuntimeLibrary(implementation(include("org.anarres:jcpp:1.4.14")))
 }
 
 processResources {
@@ -102,7 +117,6 @@ shadowJar {
 	from jar.archiveFile
 
 	relocate 'org.apache.commons.collections4', 'oculus.org.apache.commons.collections4'
-	relocate 'org.antlr', 'oculus.org.antlr'
 
 	archiveClassifier.set "shadow"
 }

--- a/glsl-relocated/build.gradle
+++ b/glsl-relocated/build.gradle
@@ -8,7 +8,9 @@ repositories {
 }
 
 dependencies {
-    implementation(shadow("io.github.douira:glsl-transformer:2.0.0"))
+    implementation(shadow("io.github.douira:glsl-transformer:2.0.0")) {
+        exclude module: "antlr4" // we only want to shadow the runtime module
+    }
     implementation shadow("org.antlr:antlr4-runtime:4.11.1")
 }
 

--- a/glsl-relocated/build.gradle
+++ b/glsl-relocated/build.gradle
@@ -1,0 +1,40 @@
+plugins {
+    id 'java-library'
+    id 'com.github.johnrengelman.shadow' version '8.1.1'
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation(shadow("io.github.douira:glsl-transformer:2.0.0"))
+    implementation shadow("org.antlr:antlr4-runtime:4.11.1")
+}
+
+shadowJar {
+    configurations = [project.configurations.shadow]
+
+    from jar.archiveFile
+
+    relocate 'org.antlr', 'oculus.org.antlr'
+
+    archiveClassifier.set "shadow"
+}
+
+
+
+configurations {
+    bundledJar {
+        canBeConsumed = true
+        canBeResolved = false
+        // If you want this configuration to share the same dependencies, otherwise omit this line
+        extendsFrom implementation, runtimeOnly
+    }
+}
+
+
+
+artifacts {
+    bundledJar(shadowJar)
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -10,3 +10,5 @@ pluginManagement {
         gradlePluginPortal()
     }
 }
+
+include("glsl-relocated")

--- a/src/main/java/net/coderbot/iris/pipeline/transform/TransformPatcher.java
+++ b/src/main/java/net/coderbot/iris/pipeline/transform/TransformPatcher.java
@@ -7,8 +7,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import net.coderbot.iris.gl.shader.ShaderCompileException;
-import org.antlr.v4.runtime.Token;
-import org.antlr.v4.runtime.misc.ParseCancellationException;
+import oculus.org.antlr.v4.runtime.Token;
+import oculus.org.antlr.v4.runtime.misc.ParseCancellationException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 


### PR DESCRIPTION
This patch heavily abuses the shadow plugin and a Gradle subproject to solve the ANTLR conflict on 1.20.1. The trick is to do the ANTLR relocation inside the subproject, and depend on *that*. This allows the main Oculus project to be compiled against the relocated package which has a different version from Forge.

~~Before releasing, we need to figure out why the production JAR is now 19MB, and fix this.~~ EDIT: Fixed, we were shadowing too much.