### PR TITLE
Fix missing dependencies causing a crash

### DIFF
--- a/src/main/java/net/coderbot/iris/mixin/OculusMixinPlugin.java
+++ b/src/main/java/net/coderbot/iris/mixin/OculusMixinPlugin.java
@@ -1,0 +1,49 @@
+package net.coderbot.iris.mixin;
+
+import net.minecraftforge.fml.loading.LoadingModList;
+import org.objectweb.asm.tree.ClassNode;
+import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
+import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
+
+import java.util.List;
+import java.util.Set;
+
+public class OculusMixinPlugin implements IMixinConfigPlugin {
+    @Override
+    public void onLoad(String s) {
+
+    }
+
+    @Override
+    public String getRefMapperConfig() {
+        return null;
+    }
+
+    @Override
+    public boolean shouldApplyMixin(String s, String s1) {
+        // Forge 1.20.1 and older load mixins even if there is a mod loading error, but
+        // don't load ATs, which causes a ton of support requests from our mixins failing
+        // to apply. The solution is to just not apply them ourselves if there is an error.
+        return LoadingModList.get().getErrors().isEmpty();
+    }
+
+    @Override
+    public void acceptTargets(Set<String> set, Set<String> set1) {
+
+    }
+
+    @Override
+    public List<String> getMixins() {
+        return List.of();
+    }
+
+    @Override
+    public void preApply(String s, ClassNode classNode, String s1, IMixinInfo iMixinInfo) {
+
+    }
+
+    @Override
+    public void postApply(String s, ClassNode classNode, String s1, IMixinInfo iMixinInfo) {
+
+    }
+}

--- a/src/main/resources/mixins.oculus.json
+++ b/src/main/resources/mixins.oculus.json
@@ -2,6 +2,7 @@
   "required": true,
   "minVersion": "0.8",
   "package": "net.coderbot.iris.mixin",
+  "plugin": "net.coderbot.iris.mixin.OculusMixinPlugin",
   "compatibilityLevel": "JAVA_8",
   "client": [
     "DimensionTypeAccessor",


### PR DESCRIPTION
This should get rid of a lot of pointless bug reports caused by a design flaw in Forge.