### PR TITLE
[1.16] Cleaner Pixelmon fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,6 @@ dependencies {
 	modCompileOnly "maven.modrinth:rubidium:0.2.13"
 	//modCompileOnly "me.jellysquid.mods:Rubidium:0.2.13"
 	modCompileOnly "curse.maven:epic-fight-mod-405076:4029362"
-	modCompileOnly "curse.maven:pixelmon-389487:4718641"
 
 	implementation fileTree(include: ['*.jar'], dir: 'libs')
 	toJar fileTree(include: ['antlr4-runtime-4.10.1.jar', 'glsl-transformer-1.0.0-pre21.2.jar'], dir: 'libs')

--- a/src/main/java/net/coderbot/iris/mixin/compat/pixelmon/MixinNormalizedFace.java
+++ b/src/main/java/net/coderbot/iris/mixin/compat/pixelmon/MixinNormalizedFace.java
@@ -1,51 +1,23 @@
 package net.coderbot.iris.mixin.compat.pixelmon;
 
-import com.mojang.blaze3d.vertex.PoseStack;
-import com.mojang.blaze3d.vertex.VertexConsumer;
-import com.mojang.math.Matrix3f;
-import com.mojang.math.Matrix4f;
-import com.pixelmonmod.pixelmon.client.models.smd.DeformVertex;
-import com.pixelmonmod.pixelmon.client.models.smd.NormalizedFace;
-import com.pixelmonmod.pixelmon.client.models.smd.TextureCoordinate;
-import com.pixelmonmod.pixelmon.client.models.smd.Vertex;
+import com.mojang.blaze3d.vertex.BufferBuilder;
+import org.objectweb.asm.Opcodes;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Overwrite;
-import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Pseudo;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Coerce;
+import org.spongepowered.asm.mixin.injection.Redirect;
 
-@Mixin(NormalizedFace.class)
+@Pseudo
+@Mixin(targets = {"com/pixelmonmod/pixelmon/client/models/smd/NormalizedFace"})
 public class MixinNormalizedFace {
-
-    @Shadow
-    public DeformVertex[] vertices;
-
-    @Shadow
-    public TextureCoordinate[] textureCoordinates;
-
-    @Shadow
-    public Vertex faceNormal;
-
-    @Shadow
-    public Vertex calculateFaceNormal() {
-        return null;
+    /**
+     * @author embeddedt (original idea by NanoLive)
+     * @reason Pixelmon manipulates the buffer of a {@link BufferBuilder} directly which causes problems.
+     * We bypass that code path.
+     */
+    @Redirect(method = "addFaceForRender", at = @At(value = "FIELD", opcode = Opcodes.GETFIELD, target = "Lcom/pixelmonmod/pixelmon/client/models/smd/DeformVertex;id2:I"))
+    public int hideBufferBuilderId(@Coerce Object instance) {
+        return -1; // prevent using "optimized" code path
     }
-
-    @Overwrite
-    public void addFaceForRender(PoseStack matrixStack, VertexConsumer bufferBuilder, int packedLight, int packedOverlay, boolean smoothShading, float partialTick, float r, float g, float b, float a) {
-        if (!smoothShading &&
-                this.faceNormal == null)
-            this.faceNormal = calculateFaceNormal();
-        for (int i = 0; i < 3; i++) {
-            Matrix4f pose = matrixStack.last().pose();
-            Matrix3f normal = matrixStack.last().normal();
-            bufferBuilder.vertex(pose.m00 * this.vertices[i]
-                    .getX(partialTick) + pose.m01 * this.vertices[i].getY(partialTick) + pose.m02 * this.vertices[i].getZ(partialTick) + pose.m03, pose.m10 * this.vertices[i]
-                    .getX(partialTick) + pose.m11 * this.vertices[i].getY(partialTick) + pose.m12 * this.vertices[i].getZ(partialTick) + pose.m13, pose.m20 * this.vertices[i]
-                    .getX(partialTick) + pose.m21 * this.vertices[i].getY(partialTick) + pose.m22 * this.vertices[i].getZ(partialTick) + pose.m23, r, g, b, a, (this.textureCoordinates[i]).u, (this.textureCoordinates[i]).v, packedOverlay, packedLight, normal.m00 * this.vertices[i]
-
-                    .getXN(partialTick) + normal.m01 * this.vertices[i].getYN(partialTick) + normal.m02 * this.vertices[i].getZN(partialTick), normal.m10 * this.vertices[i]
-                    .getXN(partialTick) + normal.m11 * this.vertices[i].getYN(partialTick) + normal.m12 * this.vertices[i].getZN(partialTick), normal.m20 * this.vertices[i]
-                    .getXN(partialTick) + normal.m21 * this.vertices[i].getYN(partialTick) + normal.m22 * this.vertices[i].getZN(partialTick));
-        }
-    }
-
 }


### PR DESCRIPTION
This reduces the dependency on Pixelmon internals and avoids needing to download a 300MB mod JAR in dev. The approach relies on bypassing the problematic code path via careful manipulation of the `if` statement that guards it.

Tested and models seem to render fine.
![2023-12-18_11 18 10](https://github.com/Asek3/Oculus/assets/42941056/733727de-de51-44d7-af7f-ef1cab056a53)
