### PR TITLE
[1.20] Retrieve TEXTURE_MAX_VALUE from compact chunk vertex

### DIFF
--- a/src/sodiumCompatibility/java/net/coderbot/iris/compat/sodium/impl/vertex_format/terrain_xhfp/XHFPModelVertexType.java
+++ b/src/sodiumCompatibility/java/net/coderbot/iris/compat/sodium/impl/vertex_format/terrain_xhfp/XHFPModelVertexType.java
@@ -7,6 +7,7 @@ import me.jellysquid.mods.sodium.client.render.chunk.vertex.format.ChunkVertexEn
 import me.jellysquid.mods.sodium.client.render.chunk.vertex.format.ChunkVertexType;
 import net.coderbot.iris.compat.sodium.impl.vertex_format.IrisChunkMeshAttributes;
 import net.coderbot.iris.compat.sodium.impl.vertex_format.IrisGlVertexAttributeFormat;
+import net.coderbot.iris.compat.sodium.mixin.vertex_format.CompactChunkVertexAccessor;
 
 /**
  * Like HFPModelVertexType, but extended to support Iris. The extensions aren't particularly efficient right now.
@@ -27,7 +28,7 @@ public class XHFPModelVertexType implements ChunkVertexType {
 		.build();
 
 	private static final int POSITION_MAX_VALUE = 65536;
-	private static final int TEXTURE_MAX_VALUE = 65536;
+	private static final int TEXTURE_MAX_VALUE = CompactChunkVertexAccessor.getTEXTURE_MAX_VALUE();
 
 	private static final float MODEL_ORIGIN = 8.0f;
 	private static final float MODEL_RANGE = 32.0f;

--- a/src/sodiumCompatibility/java/net/coderbot/iris/compat/sodium/mixin/vertex_format/CompactChunkVertexAccessor.java
+++ b/src/sodiumCompatibility/java/net/coderbot/iris/compat/sodium/mixin/vertex_format/CompactChunkVertexAccessor.java
@@ -1,0 +1,13 @@
+package net.coderbot.iris.compat.sodium.mixin.vertex_format;
+
+import me.jellysquid.mods.sodium.client.render.chunk.vertex.format.impl.CompactChunkVertex;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(CompactChunkVertex.class)
+public interface CompactChunkVertexAccessor {
+    @Accessor
+    static int getTEXTURE_MAX_VALUE() {
+        throw new AssertionError();
+    }
+}

--- a/src/sodiumCompatibility/resources/mixins.oculus.compat.sodium.json
+++ b/src/sodiumCompatibility/resources/mixins.oculus.compat.sodium.json
@@ -46,6 +46,7 @@
     "sky.MixinLevelRenderer",
     "vertex_format.entity.MixinEntityRenderDispatcher",
     "vertex_format.entity.MixinModelVertex",
+    "vertex_format.CompactChunkVertexAccessor",
     "vertex_format.ChunkMeshAttributeAccessor",
     "vertex_format.GlVertexAttributeFormatAccessor",
     "vertex_format.MixinChunkMeshAttribute",


### PR DESCRIPTION
A future version of Embeddium will likely make changes to the value of `TEXTURE_MAX_VALUE` in order to backport https://github.com/CaffeineMC/sodium-fabric/commit/c674e7b5816e5c2fe6fe12512e65510e6b573fa0. This will break Oculus code that hardcodes the previous value. To solve this, the value should be retrieved from Embeddium's CompactChunkVertex rather than hardcoding it.

Ideally, this change should also be backported to 1.18 & 1.19, as I suspect it can cause issues on those two versions as well. 