### PR TITLE
[1.20] Update texture encoding

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -102,7 +102,7 @@ dependencies {
 	mappings loom.officialMojangMappings()
 	forge "net.minecraftforge:forge:${minecraft_version}-${forge_version}"
 
-	modImplementation "org.embeddedt:embeddium-${minecraft_version}:${embeddium_version}"
+	modCompileOnly "org.embeddedt:embeddium-${minecraft_version}:${embeddium_version}"
 	compileOnly "maven.modrinth:distanthorizons:2.0.1-a-1.20.1"
 
 	forgeRuntimeLibrary(implementation(shadow(project(path: ":glsl-relocated", configuration: "bundledJar")))) {

--- a/build.gradle
+++ b/build.gradle
@@ -102,7 +102,7 @@ dependencies {
 	mappings loom.officialMojangMappings()
 	forge "net.minecraftforge:forge:${minecraft_version}-${forge_version}"
 
-	modCompileOnly "org.embeddedt:embeddium-${minecraft_version}:${embeddium_version}"
+	modImplementation "org.embeddedt:embeddium-${minecraft_version}:${embeddium_version}"
 	compileOnly "maven.modrinth:distanthorizons:2.0.1-a-1.20.1"
 
 	forgeRuntimeLibrary(implementation(shadow(project(path: ":glsl-relocated", configuration: "bundledJar")))) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,4 +14,4 @@ loom.platform = forge
 	archives_base_name = oculus
 
 # Dependencies
-	embeddium_version=0.2.12-git.149aa28+mc1.20.1
+	embeddium_version=0.2.14-git.dbe9f77+mc1.20.1

--- a/src/main/java/net/coderbot/iris/pipeline/SodiumTerrainPipeline.java
+++ b/src/main/java/net/coderbot/iris/pipeline/SodiumTerrainPipeline.java
@@ -127,7 +127,7 @@ public class SodiumTerrainPipeline {
 
 		void _vert_init() {
 			_vert_position = (vec3(a_PosId.xyz) * 4.8828125E-4f + -8.0f);
-			_vert_tex_diffuse_coord = (a_TexCoord * 1.52587891E-5f);
+			_vert_tex_diffuse_coord = (a_TexCoord * 1.0f / 32768.0f);
 			_vert_tex_light_coord = a_LightCoord;
 			_vert_color = a_Color;
 			_draw_id = (a_PosId.w >> 8u) & 0xffu;

--- a/src/main/java/net/coderbot/iris/pipeline/transform/transformer/SodiumTransformer.java
+++ b/src/main/java/net/coderbot/iris/pipeline/transform/transformer/SodiumTransformer.java
@@ -28,7 +28,7 @@ public class SodiumTransformer {
 		SodiumParameters parameters) {
 		CommonTransformer.transform(t, tree, root, parameters, false);
 
-		replaceMidTexCoord(t, tree, root, 1.0f / 65536.0f);
+		replaceMidTexCoord(t, tree, root, 1.0f / 32768.0f);
 
 		root.replaceExpressionMatches(t, CommonTransformer.glTextureMatrix0, "mat4(1.0)");
 		root.replaceExpressionMatches(t, CommonTransformer.glTextureMatrix1, "iris_LightmapTextureMatrix");
@@ -150,7 +150,7 @@ public class SodiumTransformer {
 			"void _vert_init() {" +
 				"_vert_position = (vec3(a_PosId.xyz) * 0.00048828125 + -8.0"
 				+ ");" +
-				"_vert_tex_diffuse_coord = (a_TexCoord * 1.52587891E-5);" +
+				"_vert_tex_diffuse_coord = (a_TexCoord * 1.0f / 32768.0f);" +
 				"_vert_tex_light_coord = a_LightCoord;" +
 				"_vert_color = " + separateAo + ";" +
 				"_draw_id = (a_PosId.w >> 8u) & 0xFFu; }",

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -26,3 +26,10 @@ mandatory = true
 versionRange = "[1.20.1]"
 ordering = "NONE"
 side = "BOTH"
+
+[[dependencies.oculus]]
+modId = "embeddium"
+mandatory = true
+versionRange = "[0.2.14,)"
+ordering = "NONE"
+side = "CLIENT"

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -29,7 +29,6 @@ side = "BOTH"
 
 [[dependencies.oculus]]
 modId = "embeddium"
-mandatory = true
 versionRange = "[0.2.14,)"
 ordering = "NONE"
 side = "CLIENT"

--- a/src/sodiumCompatibility/java/net/coderbot/iris/compat/sodium/impl/vertex_format/terrain_xhfp/XHFPModelVertexType.java
+++ b/src/sodiumCompatibility/java/net/coderbot/iris/compat/sodium/impl/vertex_format/terrain_xhfp/XHFPModelVertexType.java
@@ -27,7 +27,7 @@ public class XHFPModelVertexType implements ChunkVertexType {
 		.build();
 
 	private static final int POSITION_MAX_VALUE = 65536;
-	private static final int TEXTURE_MAX_VALUE = 65536;
+	private static final int TEXTURE_MAX_VALUE = 32768;
 
 	private static final float MODEL_ORIGIN = 8.0f;
 	private static final float MODEL_RANGE = 32.0f;
@@ -48,7 +48,7 @@ public class XHFPModelVertexType implements ChunkVertexType {
 	}
 
 	static short encodeBlockTexture(float value) {
-		return (short) (Math.min(0.99999997F, value) * TEXTURE_MAX_VALUE);
+		return (short) (Math.round(value * TEXTURE_MAX_VALUE) & 0xFFFF);
 	}
 
 	static float decodeBlockTexture(short raw) {


### PR DESCRIPTION
The next version of Embeddium will make a backwards-incompatible change to how textures are encoded to address visual alignment issues (this change will also be made in Sodium whenever the next release occurs). It will require an Oculus update for shaders to function correctly again.

The reverse is also true: older versions of Embeddium will not work with an Oculus version including this change. However I don't think that's an issue.