### PR TITLE
Fix memory corruption caused by GlyphExtVertexSerializer

### DIFF
--- a/src/sodiumCompatibility/java/net/irisshaders/iris/compat/sodium/impl/vertex_format/GlyphExtVertexSerializer.java
+++ b/src/sodiumCompatibility/java/net/irisshaders/iris/compat/sodium/impl/vertex_format/GlyphExtVertexSerializer.java
@@ -22,11 +22,11 @@ public class GlyphExtVertexSerializer implements VertexSerializer {
 	private static final Vector3f saveNormal = new Vector3f();
 	private static final int STRIDE = IrisVertexFormats.GLYPH.getVertexSize();
 
-	private static void endQuad(float uSum, float vSum, long src, long dst) {
+	private static void endQuad(float uSum, float vSum, long dst) {
 		uSum *= 0.25f;
 		vSum *= 0.25f;
 
-		quad.setup(src, IrisVertexFormats.GLYPH.getVertexSize());
+		quad.setup(dst, STRIDE);
 
 		float normalX, normalY, normalZ;
 
@@ -48,6 +48,11 @@ public class GlyphExtVertexSerializer implements VertexSerializer {
 
 	@Override
 	public void serialize(long src, long dst, int vertexCount) {
+		// The code below assumes there are exactly 4 vertices being pushed
+		if (vertexCount != 4) {
+			throw new IllegalStateException();
+		}
+
 		float uSum = 0.0f, vSum = 0.0f;
 
 		for (int i = 0; i < vertexCount; i++) {
@@ -64,9 +69,9 @@ public class GlyphExtVertexSerializer implements VertexSerializer {
 			MemoryUtil.memPutShort(dst + 36, (short) CapturedRenderingState.INSTANCE.getCurrentRenderedItem());
 
 			src += DefaultVertexFormat.POSITION_COLOR_TEX_LIGHTMAP.getVertexSize();
-			dst += IrisVertexFormats.GLYPH.getVertexSize();
+			dst += STRIDE;
 		}
 
-		endQuad(uSum, vSum, src, dst);
+		endQuad(uSum, vSum, dst - STRIDE); // Point to the *start* of the last vertex.
 	}
 }


### PR DESCRIPTION
The Iris 1.7.x implementation of `GlyphExtVertexSerializer` performs out-of-bounds memory reads & writes when extending the vertex data. This leads to unpredictable behavior including consistent JVM native crashes on some platforms.

There are several problems in the original code:
* The quad view is set up using the extended format's stride, but reads from the source buffer which contains data aligned for the non-extended format.
* The quad view is set up using a pointer that points to the *end* of the last vertex, but the logic inside expects the pointer to point at the *start* of the last vertex.

While investigating this problem, I determined the bug was quietly fixed upstream in [this Iris commit for 1.8.0-beta.1](https://github.com/IrisShaders/Iris/commit/25e3bc179b30916235d492104d0a3003a33a4040#diff-b2f8b1738772492fb47f54b5c13ff47e730cc665b3c7771a645c3023cc33c6b9). The fix does not appear to have been backported to any 1.7.x releases; as such, previous releases of Iris for Fabric are likely also affected.

I have confirmed, through testing, that a certain class of JVM crashes appear to be resolved by this change.