### PR TITLE
Fix crash with Mekanism flamethrowers

### DIFF
--- a/src/main/java/net/irisshaders/iris/pathways/LightningHandler.java
+++ b/src/main/java/net/irisshaders/iris/pathways/LightningHandler.java
@@ -34,7 +34,7 @@ public class LightningHandler extends RenderType {
 				.setTextureState(new RenderStateShard.TextureStateShard(resourceLocation, false, false))
 				.setTransparencyState(TRANSLUCENT_TRANSPARENCY)
 				.createCompositeState(true);
-		return create("mek_flame", DefaultVertexFormat.POSITION_TEX_COLOR, VertexFormat.Mode.QUADS, 256, true, false, state);
+		return create("mek_flame", DefaultVertexFormat.POSITION_COLOR_TEX, VertexFormat.Mode.QUADS, 256, true, false, state);
 	});
 
 	public static final RenderType MEKASUIT = create("mekasuit", DefaultVertexFormat.NEW_ENTITY, VertexFormat.Mode.QUADS, 131_072, true, false,


### PR DESCRIPTION
Compared this to Mekanism's source of the render definition - this was the only noticeable change I found, and I presume it's just a typo. Tested working with Mekanism 10.4.14.71.

Fixes #749.