### PR TITLE
[1.19.2] Add MixinForgeTranslucentShader

### DIFF
--- a/src/main/java/net/coderbot/iris/mixin/MixinForgeTranslucentShader.java
+++ b/src/main/java/net/coderbot/iris/mixin/MixinForgeTranslucentShader.java
@@ -1,0 +1,51 @@
+package net.coderbot.iris.mixin;
+
+import net.coderbot.iris.Iris;
+import net.coderbot.iris.pipeline.ShadowRenderer;
+import net.coderbot.iris.pipeline.WorldRenderingPipeline;
+import net.coderbot.iris.pipeline.newshader.CoreWorldRenderingPipeline;
+import net.coderbot.iris.pipeline.newshader.ShaderKey;
+
+import net.minecraftforge.client.ForgeHooksClient;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+
+import net.minecraft.client.renderer.ShaderInstance;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(ForgeHooksClient.ClientEvents.class)
+public class MixinForgeTranslucentShader {
+
+    @Inject(method = {"getEntityTranslucentUnlitShader"}, at = @At("HEAD"), cancellable = true, remap = false)
+    private static void iris$overrideForgeTranslucentShader(CallbackInfoReturnable<ShaderInstance> cir) {
+        if (ShadowRenderer.ACTIVE) {
+            override(ShaderKey.SHADOW_ENTITIES_CUTOUT, cir);
+        }
+        else if (shouldOverrideShaders()) {
+            override(ShaderKey.ENTITIES_TRANSLUCENT, cir);
+        }
+    }
+
+    private static boolean shouldOverrideShaders() {
+        WorldRenderingPipeline pipeline = Iris.getPipelineManager().getPipelineNullable();
+
+        if (pipeline instanceof CoreWorldRenderingPipeline) {
+            return ((CoreWorldRenderingPipeline) pipeline).shouldOverrideShaders();
+        } else {
+            return false;
+        }
+    }
+
+    private static void override(ShaderKey key, CallbackInfoReturnable<ShaderInstance> cir) {
+        WorldRenderingPipeline pipeline = Iris.getPipelineManager().getPipelineNullable();
+
+        if (pipeline instanceof CoreWorldRenderingPipeline) {
+            ShaderInstance override = ((CoreWorldRenderingPipeline) pipeline).getShaderMap().getShader(key);
+
+            if (override != null) {
+                cir.setReturnValue(override);
+            }
+        }
+    }
+}

--- a/src/main/resources/mixins.oculus.json
+++ b/src/main/resources/mixins.oculus.json
@@ -17,6 +17,7 @@
     "MixinTheEndPortalRenderer",
     "MixinEntityRenderDispatcher",
     "MixinFogRenderer",
+    "MixinForgeTranslucentShader",
     "MixinGameRenderer",
     "MixinGameRenderer_NightVisionCompat",
     "MixinProgram",


### PR DESCRIPTION
Add mixin to fix items which make use of emissive layers or fullbright light textures. This is a code provided by @Marco6789 in #630.

There is a comment that everything should work now, but for current 1.19.2 (1.6.9a) release it does not. 

I've tested it and this mixin fixes issues with Fiery armor/weapons in Twilight Forest

<details>
  <summary>Screenshots</summary>
  <img src="https://github.com/user-attachments/assets/627688c1-1bcd-430a-a981-90156320b7c0" />
  <img src="https://github.com/user-attachments/assets/7a0df385-1e1a-4700-89c5-98c54d9e0196" />
</details>