### PR TITLE
[1.20.1] Update embeddium to lastest

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,4 +14,4 @@ loom.platform = forge
 	archives_base_name = oculus
 
 # Dependencies
-	embeddium_version=0.3.14-git.8af1729+mc1.20.1
+	embeddium_version=0.3.31-beta.53+mc1.20.1

--- a/src/sodiumCompatibility/java/net/irisshaders/iris/compat/sodium/mixin/copyEntity/CuboidMixin.java
+++ b/src/sodiumCompatibility/java/net/irisshaders/iris/compat/sodium/mixin/copyEntity/CuboidMixin.java
@@ -4,6 +4,7 @@ import me.jellysquid.mods.sodium.client.model.ModelCuboidAccessor;
 import me.jellysquid.mods.sodium.client.render.immediate.model.ModelCuboid;
 import net.minecraft.client.model.geom.ModelPart;
 import net.minecraft.core.Direction;
+import org.jetbrains.annotations.Nullable;
 import org.objectweb.asm.Opcodes;
 import org.spongepowered.asm.mixin.*;
 import org.spongepowered.asm.mixin.injection.At;
@@ -17,6 +18,8 @@ import java.util.Set;
 public class CuboidMixin implements ModelCuboidAccessor {
 	@Unique
 	private ModelCuboid sodium$cuboid;
+	@Unique
+	private ModelCuboid embeddium$simpleCuboid;
 
 	@Mutable
 	@Shadow
@@ -27,6 +30,7 @@ public class CuboidMixin implements ModelCuboidAccessor {
 	@Redirect(method = "<init>", at = @At(value = "FIELD", opcode = Opcodes.PUTFIELD, target = "Lnet/minecraft/client/model/geom/ModelPart$Cube;minX:F", ordinal = 0))
 	private void onInit(ModelPart.Cube instance, float value, int u, int v, float x, float y, float z, float sizeX, float sizeY, float sizeZ, float extraX, float extraY, float extraZ, boolean mirror, float textureWidth, float textureHeight, Set<Direction> renderDirections) {
 		this.sodium$cuboid = new ModelCuboid(u, v, x, y, z, sizeX, sizeY, sizeZ, extraX, extraY, extraZ, mirror, textureWidth, textureHeight, renderDirections);
+		this.embeddium$simpleCuboid = (Class<?>)getClass() == ModelPart.Cube.class ? this.sodium$cuboid : null;
 
 		this.minX = value;
 	}
@@ -34,5 +38,10 @@ public class CuboidMixin implements ModelCuboidAccessor {
 	@Override
 	public ModelCuboid sodium$copy() {
 		return this.sodium$cuboid;
+	}
+
+	@Override
+	public @Nullable ModelCuboid embeddium$getSimpleCuboid() {
+		return this.embeddium$simpleCuboid;
 	}
 }


### PR DESCRIPTION
My mods uses embeddium$getSimpleCuboid to get ModelCuboid which do not exist in an older version of embeddium

It causes crashes when my mod is installed alongside Oculus and certain other specific mods. (which calls ModelPart.Cube.compile directly)

Could Oculus update embeddium to the lastest version ?

Issue https://github.com/MoePus/Flerovium/issues/28