### PR TITLE
Fix separate entity draw buffer ownership

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ loom.platform = forge
 	forge_version=47.1.105
 
 # Mod Properties
-	mod_version = 1.8.0-decoderfix.3
+	mod_version = 1.8.0-decoderfix.4
 	maven_group = net.coderbot
 	archives_base_name = oculus
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ loom.platform = forge
 	forge_version=47.1.105
 
 # Mod Properties
-	mod_version = 1.8.0
+	mod_version = 1.8.0-decoderfix.1
 	maven_group = net.coderbot
 	archives_base_name = oculus
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ loom.platform = forge
 	forge_version=47.1.105
 
 # Mod Properties
-	mod_version = 1.8.0-decoderfix.1
+	mod_version = 1.8.0-decoderfix.2
 	maven_group = net.coderbot
 	archives_base_name = oculus
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ loom.platform = forge
 	forge_version=47.1.105
 
 # Mod Properties
-	mod_version = 1.8.0-decoderfix.2
+	mod_version = 1.8.0-decoderfix.3
 	maven_group = net.coderbot
 	archives_base_name = oculus
 

--- a/src/main/java/net/irisshaders/batchedentityrendering/impl/FullyBufferedMultiBufferSource.java
+++ b/src/main/java/net/irisshaders/batchedentityrendering/impl/FullyBufferedMultiBufferSource.java
@@ -59,7 +59,7 @@ public class FullyBufferedMultiBufferSource extends MultiBufferSource.BufferSour
 
 	@Override
 	public VertexConsumer getBuffer(RenderType renderType) {
-		removeReady();
+		if (isReady) endBatch();
 
 		if (wrappingFunction != null) {
 			renderType = wrappingFunction.apply(renderType);

--- a/src/main/java/net/irisshaders/batchedentityrendering/mixin/MixinRenderBuffers.java
+++ b/src/main/java/net/irisshaders/batchedentityrendering/mixin/MixinRenderBuffers.java
@@ -5,6 +5,7 @@ import net.irisshaders.batchedentityrendering.impl.FullyBufferedMultiBufferSourc
 import net.irisshaders.batchedentityrendering.impl.MemoryTrackingBuffer;
 import net.irisshaders.batchedentityrendering.impl.MemoryTrackingRenderBuffers;
 import net.irisshaders.batchedentityrendering.impl.RenderBuffersExt;
+import net.irisshaders.iris.pathways.HandRenderer;
 import net.minecraft.client.renderer.ChunkBufferBuilderPack;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.OutlineBufferSource;
@@ -41,6 +42,11 @@ public class MixinRenderBuffers implements RenderBuffersExt, MemoryTrackingRende
 
 	@Inject(method = "bufferSource", at = @At("HEAD"), cancellable = true)
 	private void batchedentityrendering$replaceBufferSource(CallbackInfoReturnable<MultiBufferSource.BufferSource> cir) {
+		if (HandRenderer.INSTANCE.isActive()) {
+			cir.setReturnValue(HandRenderer.INSTANCE.getBufferSource());
+			return;
+		}
+
 		if (begins == 0) {
 			return;
 		}

--- a/src/main/java/net/irisshaders/iris/mixin/MixinGameRenderer.java
+++ b/src/main/java/net/irisshaders/iris/mixin/MixinGameRenderer.java
@@ -458,6 +458,19 @@ public class MixinGameRenderer {
 		itemInHandRenderer.renderHandsWithItems(tickDelta, poseStack, bufferSource, localPlayer, light);
 	}
 
+	@Inject(
+		method = "renderLevel",
+		at = @At(
+			value = "INVOKE",
+			target = "Lnet/minecraftforge/client/ForgeHooksClient;dispatchRenderStage(Lnet/minecraftforge/client/event/RenderLevelStageEvent$Stage;Lnet/minecraft/client/renderer/LevelRenderer;Lcom/mojang/blaze3d/vertex/PoseStack;Lorg/joml/Matrix4f;ILnet/minecraft/client/Camera;Lnet/minecraft/client/renderer/culling/Frustum;)V",
+			shift = At.Shift.AFTER,
+			remap = false
+		)
+	)
+	private void iris$finalizeLevelAfterForge(float tickDelta, long limitTime, PoseStack poseStack, CallbackInfo ci) {
+		Iris.getPipelineManager().getPipeline().ifPresent(WorldRenderingPipeline::finalizeLevelRendering);
+	}
+
 	@Inject(method = "renderLevel", at = @At("TAIL"))
 	private void iris$runColorSpace(float pGameRenderer0, long pLong1, PoseStack pPoseStack2, CallbackInfo ci) {
 		Iris.getPipelineManager().getPipeline().ifPresent(WorldRenderingPipeline::finalizeGameRendering);

--- a/src/main/java/net/irisshaders/iris/mixin/MixinLevelRenderer.java
+++ b/src/main/java/net/irisshaders/iris/mixin/MixinLevelRenderer.java
@@ -104,13 +104,12 @@ public class MixinLevelRenderer {
 	}
 
 
-	// Inject a bit early so that we can end our rendering before mods like VoxelMap (which inject at RETURN)
-	// render their waypoint beams.
+	// Render the translucent hand here, but keep the pipeline active for Forge's AFTER_LEVEL render stage.
+	// Forge dispatches that stage from GameRenderer after this method returns.
 	@Inject(method = RENDER, at = @At(value = "RETURN", shift = At.Shift.BEFORE))
 	private void iris$endLevelRender(PoseStack poseStack, float tickDelta, long limitTime, boolean renderBlockOutline, Camera camera, GameRenderer gameRenderer, LightTexture lightTexture, Matrix4f projectionMatrix, CallbackInfo callback) {
 		HandRenderer.INSTANCE.renderTranslucent(poseStack, tickDelta, camera, gameRenderer, pipeline);
 		Minecraft.getInstance().getProfiler().popPush("iris_final");
-		pipeline.finalizeLevelRendering();
 		pipeline = null;
 
 		if (Iris.shouldActivateWireframe() && this.minecraft.isLocalServer()) {

--- a/src/main/java/net/irisshaders/iris/mixin/MixinRenderSystem.java
+++ b/src/main/java/net/irisshaders/iris/mixin/MixinRenderSystem.java
@@ -4,16 +4,23 @@ import com.mojang.blaze3d.systems.RenderSystem;
 import net.irisshaders.iris.Iris;
 import net.irisshaders.iris.gl.GLDebug;
 import net.irisshaders.iris.gl.IrisRenderSystem;
+import net.irisshaders.iris.pipeline.ShaderRenderingPipeline;
 import net.irisshaders.iris.samplers.IrisSamplers;
 import net.irisshaders.iris.texture.TextureTracker;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.GameRenderer;
+import net.minecraft.client.renderer.ShaderInstance;
 import net.minecraft.client.renderer.texture.AbstractTexture;
 import net.minecraft.client.renderer.texture.TextureManager;
 import net.minecraft.resources.ResourceLocation;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+
+import java.util.function.Supplier;
 
 @Mixin(RenderSystem.class)
 public class MixinRenderSystem {
@@ -34,5 +41,21 @@ public class MixinRenderSystem {
 	@Inject(method = "_setShaderTexture(II)V", at = @At("RETURN"), remap = false)
 	private static void _setShaderTexture(int unit, int glId, CallbackInfo ci) {
 		TextureTracker.INSTANCE.onSetShaderTexture(unit, glId);
+	}
+
+	@Redirect(
+		method = "setShader",
+		at = @At(value = "INVOKE", target = "Ljava/util/function/Supplier;get()Ljava/lang/Object;", remap = false),
+		remap = false
+	)
+	private static Object iris$replaceProjectRedHaloShader(Supplier<ShaderInstance> supplier) {
+		ShaderInstance shader = supplier.get();
+		return shader != null
+			&& "projectred_core:halo".equals(shader.getName())
+			&& !Minecraft.useShaderTransparency()
+			&& Iris.getPipelineManager().getPipelineNullable() instanceof ShaderRenderingPipeline pipeline
+			&& pipeline.shouldOverrideShaders()
+			? GameRenderer.getPositionColorShader()
+			: shader;
 	}
 }

--- a/src/main/java/net/irisshaders/iris/mixin/vertices/block_rendering/MixinLightMatrix_SeparateAo.java
+++ b/src/main/java/net/irisshaders/iris/mixin/vertices/block_rendering/MixinLightMatrix_SeparateAo.java
@@ -1,0 +1,33 @@
+package net.irisshaders.iris.mixin.vertices.block_rendering;
+
+import net.irisshaders.iris.shaderpack.materialmap.WorldRenderingSettings;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Pseudo;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Pseudo
+@Mixin(targets = "codechicken.lib.render.lighting.LightMatrix", remap = false)
+public abstract class MixinLightMatrix_SeparateAo {
+	@Redirect(
+		method = "operate",
+		at = @At(
+			value = "INVOKE",
+			target = "Lcodechicken/lib/colour/ColourRGBA;multiplyC(IF)I",
+			remap = false
+		),
+		require = 0,
+		remap = false
+	)
+	private int iris$separateAo(int color, float ao) {
+		if (WorldRenderingSettings.INSTANCE.shouldUseSeparateAo()) {
+			int alpha = Math.max(0, Math.min(255, Math.round(ao * 255.0f)));
+			return (color & 0xFFFFFF00) | alpha;
+		}
+
+		int red = (int) ((color >>> 24) * ao);
+		int green = (int) (((color >>> 16) & 0xFF) * ao);
+		int blue = (int) (((color >>> 8) & 0xFF) * ao);
+		return (red << 24) | (green << 16) | (blue << 8) | (color & 0xFF);
+	}
+}

--- a/src/main/java/net/irisshaders/iris/mixin/vertices/block_rendering/MixinLightMatrix_SeparateAo.java
+++ b/src/main/java/net/irisshaders/iris/mixin/vertices/block_rendering/MixinLightMatrix_SeparateAo.java
@@ -1,14 +1,40 @@
 package net.irisshaders.iris.mixin.vertices.block_rendering;
 
 import net.irisshaders.iris.shaderpack.materialmap.WorldRenderingSettings;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Pseudo;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Pseudo
 @Mixin(targets = "codechicken.lib.render.lighting.LightMatrix", remap = false)
 public abstract class MixinLightMatrix_SeparateAo {
+	@Shadow(remap = false)
+	@Final
+	private static float[] sideao;
+
+	@Unique
+	private static final float[] iris$NO_DIRECTIONAL_SHADE = {
+		1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f
+	};
+
+	@Redirect(
+		method = "interp",
+		at = @At(
+			value = "FIELD",
+			target = "Lcodechicken/lib/render/lighting/LightMatrix;sideao:[F",
+			remap = false
+		),
+		require = 0,
+		remap = false
+	)
+	private float[] iris$selectAoShadeFactors() {
+		return WorldRenderingSettings.INSTANCE.shouldDisableDirectionalShading() ? iris$NO_DIRECTIONAL_SHADE : sideao;
+	}
+
 	@Redirect(
 		method = "operate",
 		at = @At(

--- a/src/main/resources/mixins.oculus.vertexformat.json
+++ b/src/main/resources/mixins.oculus.vertexformat.json
@@ -8,6 +8,7 @@
     "MixinVertexFormat",
     "MixinVertexFormatElement",
     "block_rendering.MixinBufferBuilder_SeparateAo",
+    "block_rendering.MixinLightMatrix_SeparateAo",
     "block_rendering.MixinChunkRebuildTask",
     "block_rendering.MixinClientLevel",
     "immediate.MixinBufferSource",


### PR DESCRIPTION
## What changed

- preserve prepared entity segments when a new segment starts
- decode CodeChickenLib's combined AO/shade value for separate draws
- route global buffer requests made during hand rendering to Oculus's existing hand buffer

## Why

With Separate Entity Draws enabled, TACZ requests and flushes
`Minecraft.renderBuffers().bufferSource()` while Oculus is in `HAND_SOLID`.
That source still owns pending world entity segments, so Create and ProjectRed
geometry can be drawn with the hand shader, projection, and depth range. The
same lifecycle could also discard prepared segments or misread CodeChickenLib
AO data.

The hand-phase guard keeps immediate TACZ stencil flushes intact while
isolating them from world buffers.

## Impact

Fixes disappearing Create contraption parts, emissive lamps visible through
walls while holding a TACZ weapon, and CodeChickenLib/CB Multipart shading
corruption with Separate Entity Draws enabled.

## Validation

- `./gradlew build`
- remapped jar bytecode inspected with `javap`
- `git diff --check`
